### PR TITLE
Aligned title to the centre conditionally

### DIFF
--- a/lib/src/widgets/drops_widget.dart
+++ b/lib/src/widgets/drops_widget.dart
@@ -7,7 +7,7 @@ class Drops {
   static void show(
     BuildContext context, {
     required String title,
-    Color? backgroundColor,
+    Color? iconColor,
     Duration duration = const Duration(seconds: 3),
     Duration? transitionDuration = const Duration(milliseconds: 700),
     TextStyle? textStyle,
@@ -25,29 +25,27 @@ class Drops {
   }) {
     OverlayEntry? currentOverlay;
     currentOverlay = OverlayEntry(
-      builder:
-          (context) => _DropsWidget(
-            title: title,
-            backgroundColor: backgroundColor,
-            duration: duration,
-            transitionDuration: transitionDuration,
-            curve: curve,
-            reverseCurve: reverseCurve,
-            isDestructive: isDestructive ?? false,
-            subtitle: subtitle,
-            titleTextStyle: titleTextStyle,
-            subtitleTextStyle: subtitleTextStyle,
-            position: position,
-            padding: padding,
-            shape: shape,
-            highContrastText: highContrastText ?? true,
-            icon: icon,
-            onDismiss: () {
-              currentOverlay?.remove();
-
-              currentOverlay = null;
-            },
-          ),
+      builder: (context) => _DropsWidget(
+        title: title,
+        backgroundColor: iconColor,
+        duration: duration,
+        transitionDuration: transitionDuration,
+        curve: curve,
+        reverseCurve: reverseCurve,
+        isDestructive: isDestructive ?? false,
+        subtitle: subtitle,
+        titleTextStyle: titleTextStyle,
+        subtitleTextStyle: subtitleTextStyle,
+        position: position,
+        padding: padding,
+        shape: shape,
+        highContrastText: highContrastText ?? true,
+        icon: icon,
+        onDismiss: () {
+          currentOverlay?.remove();
+          currentOverlay = null;
+        },
+      ),
     );
     Overlay.of(context).insert(currentOverlay!);
   }
@@ -73,28 +71,29 @@ class _DropsWidget extends StatefulWidget {
 
   const _DropsWidget({
     required this.title,
-    this.backgroundColor,
     required this.duration,
-    this.curve = Curves.fastEaseInToSlowEaseOut,
-    this.reverseCurve,
     required this.onDismiss,
+    this.highContrastText = true,
+    this.isDestructive = false,
+    this.curve = Curves.fastEaseInToSlowEaseOut,
+    this.shape = DropShape.pill,
+    this.reverseCurve,
+    this.backgroundColor,
     this.icon,
     this.subtitle,
     this.transitionDuration,
-    this.isDestructive = false,
     this.titleTextStyle,
     this.subtitleTextStyle,
     this.position,
     this.padding,
-    this.shape = DropShape.pill,
-    this.highContrastText = true,
   });
 
   @override
   _DropsWidgetState createState() => _DropsWidgetState();
 }
 
-class _DropsWidgetState extends State<_DropsWidget> with TickerProviderStateMixin {
+class _DropsWidgetState extends State<_DropsWidget>
+    with TickerProviderStateMixin {
   late AnimationController _animationController;
   late Animation<Offset> _offsetAnimation;
 
@@ -104,7 +103,8 @@ class _DropsWidgetState extends State<_DropsWidget> with TickerProviderStateMixi
   void initState() {
     super.initState();
 
-    _animationController = AnimationController(duration: widget.transitionDuration, vsync: this);
+    _animationController =
+        AnimationController(duration: widget.transitionDuration, vsync: this);
 
     _offsetAnimation = Tween<Offset>(
       begin: Offset(0, widget.position == DropPosition.top ? -1 : 1),
@@ -124,11 +124,13 @@ class _DropsWidgetState extends State<_DropsWidget> with TickerProviderStateMixi
     });
 
     _scrollController.addListener(() {
-      if (_scrollController.offset > 30 && widget.position == DropPosition.top) {
+      if (_scrollController.offset > 30 &&
+          widget.position == DropPosition.top) {
         _dismissAlert();
       }
 
-      if (_scrollController.offset < -30 && widget.position == DropPosition.bottom) {
+      if (_scrollController.offset < -30 &&
+          widget.position == DropPosition.bottom) {
         _dismissAlert();
       }
     });
@@ -149,10 +151,15 @@ class _DropsWidgetState extends State<_DropsWidget> with TickerProviderStateMixi
 
   @override
   Widget build(BuildContext context) {
+    // get the iconSize to create balanced padding (default is 24)
+    final double iconSize = widget.icon != null ? 24.0 : 0;
+
     return Positioned(
       left: 0,
       top: widget.position == DropPosition.top ? 0 : null,
-      bottom: widget.position == DropPosition.bottom ? 0 + MediaQuery.of(context).viewPadding.bottom : null,
+      bottom: widget.position == DropPosition.bottom
+          ? 0 + MediaQuery.of(context).viewPadding.bottom
+          : null,
       right: 0,
       child: SlideTransition(
         position: _offsetAnimation,
@@ -160,12 +167,17 @@ class _DropsWidgetState extends State<_DropsWidget> with TickerProviderStateMixi
           clipBehavior: Clip.none,
           controller: _scrollController,
           hitTestBehavior: HitTestBehavior.deferToChild,
-          physics: const AlwaysScrollableScrollPhysics(parent: BouncingScrollPhysics()),
+          physics: const AlwaysScrollableScrollPhysics(
+              parent: BouncingScrollPhysics()),
           child: SafeArea(
             child: Center(
               child: Container(
-                margin: const EdgeInsets.symmetric(horizontal: 10),
-                clipBehavior: widget.shape == DropShape.squared ? Clip.none : Clip.antiAlias,
+                margin: EdgeInsets.symmetric(
+                  horizontal: widget.position == DropPosition.top ? 10 : 0,
+                ),
+                clipBehavior: widget.shape == DropShape.squared
+                    ? Clip.none
+                    : Clip.antiAlias,
                 decoration: ShapeDecoration(
                   shape: const StadiumBorder(),
                   shadows: [
@@ -177,83 +189,86 @@ class _DropsWidgetState extends State<_DropsWidget> with TickerProviderStateMixi
                     ),
                   ],
                 ),
-                child: CupertinoPopupSurface(
-                  child: Padding(
-                    padding:
-                        widget.padding ??
-                        EdgeInsets.only(
-                          left: widget.subtitle != null && widget.icon == null ? 30 : 20,
-                          right:
-                              widget.icon != null
-                                  ? 28
-                                  : widget.subtitle != null
-                                  ? 30
-                                  : 20,
-                          top: widget.subtitle != null ? 10 : 16,
-                          bottom: widget.subtitle != null ? 10 : 16,
-                        ),
-                    child: Row(
-                      spacing: 11,
-                      mainAxisSize: MainAxisSize.min,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        if (widget.icon != null)
-                          Icon(
-                            widget.icon,
-                            color:
-                                widget.isDestructive
-                                    ? CupertinoColors.destructiveRed.resolveFrom(context)
-                                    : CupertinoColors.secondaryLabel.resolveFrom(context),
+                child: Material(
+                  type: MaterialType.transparency,
+                  child: CupertinoPopupSurface(
+                    child: Padding(
+                      padding: widget.padding ??
+                          EdgeInsets.symmetric(
+                            horizontal: 20,
+                            vertical: widget.subtitle != null ? 10 : 16,
                           ),
-                        Flexible(
-                          child: Column(
-                            mainAxisSize: MainAxisSize.min,
-                            crossAxisAlignment: CrossAxisAlignment.center,
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Text(
-                                widget.title,
-                                overflow: TextOverflow.ellipsis,
-                                maxLines: 1,
-                                style:
-                                    widget.titleTextStyle ??
-                                    TextStyle(
-                                      color:
-                                          widget.highContrastText
-                                              ? CupertinoColors.label.resolveFrom(context)
-                                              : CupertinoColors.secondaryLabel.resolveFrom(context),
-                                      fontSize: 15,
-                                      fontWeight: FontWeight.w600,
-                                    ),
-                                textAlign: TextAlign.center,
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        spacing: 11,
+                        children: [
+                          if (widget.icon != null)
+                            Icon(
+                              widget.icon,
+                              color: widget.isDestructive
+                                  ? CupertinoColors.destructiveRed
+                                      .resolveFrom(context)
+                                  : CupertinoColors.secondaryLabel
+                                      .resolveFrom(context),
+                            ),
+                          Flexible(
+                            child: Padding(
+                              // make the text centered overall by adding padding
+                              padding: EdgeInsets.only(
+                                right: widget.icon != null &&
+                                        widget.subtitle != null
+                                    ? iconSize
+                                    : 0,
                               ),
-                              if (widget.subtitle != null)
-                                Column(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
-                                    const SizedBox(height: 3),
-                                    Text(
-                                      overflow: TextOverflow.ellipsis,
-                                      maxLines: 1,
-                                      widget.subtitle!,
-                                      style:
-                                          widget.subtitleTextStyle ??
-                                          TextStyle(
-                                            color:
-                                                widget.highContrastText
-                                                    ? CupertinoColors.secondaryLabel.resolveFrom(context)
-                                                    : CupertinoColors.tertiaryLabel.resolveFrom(context),
-                                            fontSize: 14,
-                                            fontWeight: FontWeight.w600,
-                                          ),
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                crossAxisAlignment: CrossAxisAlignment.center,
+                                children: [
+                                  Text(
+                                    widget.title,
+                                    overflow: TextOverflow.ellipsis,
+                                    maxLines: 1,
+                                    style: widget.titleTextStyle ??
+                                        TextStyle(
+                                          color: widget.highContrastText
+                                              ? CupertinoColors.label
+                                                  .resolveFrom(context)
+                                              : CupertinoColors.secondaryLabel
+                                                  .resolveFrom(context),
+                                          fontSize: 15,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                    textAlign: TextAlign.center,
+                                  ),
+                                  if (widget.subtitle != null)
+                                    Column(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        const SizedBox(height: 3),
+                                        Text(
+                                          widget.subtitle!,
+                                          style: widget.subtitleTextStyle ??
+                                              TextStyle(
+                                                color: widget.highContrastText
+                                                    ? CupertinoColors
+                                                        .secondaryLabel
+                                                        .resolveFrom(context)
+                                                    : CupertinoColors
+                                                        .tertiaryLabel
+                                                        .resolveFrom(context),
+                                                fontSize: 14,
+                                                fontWeight: FontWeight.w600,
+                                              ),
+                                          textAlign: TextAlign.center,
+                                        ),
+                                      ],
                                     ),
-                                  ],
-                                ),
-                            ],
+                                ],
+                              ),
+                            ),
                           ),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
                 ),


### PR DESCRIPTION
Previously title was a bit shifted to the right due to the leading icon when it was visible, this is noticeable if subtitle isn't null. which made the title aligned relative to the Flexible column it was in instead of the Actual main widget (that's how Apple displays theirs if you toggle DnD/any focus  mode).

![IMG_7159](https://github.com/user-attachments/assets/f3b98fd5-804b-4db1-a468-f085cbf70733)

